### PR TITLE
shell: add support for Dualscreen/Multihead presentation mode

### DIFF
--- a/libview/ev-view-presentation.h
+++ b/libview/ev-view-presentation.h
@@ -48,6 +48,8 @@ GtkWidget      *ev_view_presentation_new	      (EvDocument         *document,
 						       guint               rotation,
 						       gboolean            inverted_colors);
 guint           ev_view_presentation_get_current_page (EvViewPresentation *pview);
+void		ev_view_presentation_set_page	      (EvViewPresentation *pview,
+					               gint 		   new_page);
 void            ev_view_presentation_next_page        (EvViewPresentation *pview);
 void            ev_view_presentation_previous_page    (EvViewPresentation *pview);
 void            ev_view_presentation_set_rotation     (EvViewPresentation *pview,

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -34,6 +34,7 @@ properties/ev-properties-view.c
 shell/eggfindbar.c
 shell/ev-annotation-properties-dialog.c
 shell/ev-application.c
+shell/ev-dualscreen.c
 shell/ev-history.c
 shell/ev-history-action-widget.c
 shell/ev-keyring.c

--- a/shell/Makefile.am
+++ b/shell/Makefile.am
@@ -17,6 +17,8 @@ evince_SOURCES=				\
 	ev-bookmark-action.c		\
 	ev-application.c		\
 	ev-application.h		\
+	ev-dualscreen.h			\
+	ev-dualscreen.c			\
 	ev-file-monitor.h		\
 	ev-file-monitor.c		\
 	ev-find-sidebar.h		\
@@ -75,6 +77,8 @@ evince_SOURCES=				\
 	ev-sidebar-page.h		\
 	ev-sidebar-thumbnails.c		\
 	ev-sidebar-thumbnails.h		\
+	ev-presentation-timer.h		\
+	ev-presentation-timer.c		\
 	main.c
 
 nodist_evince_SOURCES = \

--- a/shell/ev-dualscreen.c
+++ b/shell/ev-dualscreen.c
@@ -1,0 +1,453 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8; c-indent-level: 8 -*- */
+/* this file is part of evince, a gnome document viewer
+ *
+ *  Copyright (C) 2007 Johannes Buchner
+ *
+ *  Author:
+ *    Johannes Buchner <buchner.johannes@gmx.at>
+ *    Lukas Bezdicka <255993@mail.muni.cz>
+ *
+ * Evince is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Evince is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <glib/gi18n.h>
+#include <gtk/gtk.h>
+
+#include "ev-dualscreen.h"
+#include "ev-view.h"
+#include "ev-utils.h"
+#include "ev-sidebar.h"
+#include "ev-sidebar-thumbnails.h"
+#include "ev-presentation-timer.h"
+
+struct _EvDSCWindowPrivate {
+	GtkWidget       *main_box;
+	GtkWidget       *menubar;
+	GtkWidget       *sidebar;
+	GtkWidget       *notesview;
+	GtkWidget       *timer;
+	GtkWidget       *spinner;
+	GtkWidget       *presentation_window;
+	GtkWidget       *overview_scrolled_window;
+	GtkWidget       *notesview_scrolled_window;
+
+	EvDocumentModel *model;
+	EvDocumentModel *notes_model;
+	EvDocument      *presentation_document;
+	EvDocument      *notes_document;
+	EvMetadata      *metadata;
+	EvViewPresentation *presentation_view;
+
+	gint		moveback_monitor;
+	gint		presentation_monitor;
+	guint		page;
+};
+
+#define EV_DSCWINDOW_GET_PRIVATE(object) \
+	(G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_DSCWINDOW, EvDSCWindowPrivate))
+#define PAGE_CACHE_SIZE 52428800 /* 50MB */
+#define SIDEBAR_DEFAULT_SIZE    30 /* This seems like bug in gtk to me */
+#define MAX_PRESENTATION_TIME   1440 /* 60*24 ONE DAY */
+
+G_DEFINE_TYPE (EvDSCWindow, ev_dscwindow, GTK_TYPE_WINDOW)
+
+static gint
+ev_dscwindow_get_presentation_window_monitor (EvDSCWindow *ev_dscwindow)
+{
+	GtkWindow *presentation_window = GTK_WINDOW (ev_dscwindow->priv->presentation_window);
+	GdkScreen *screen = gtk_window_get_screen (presentation_window);
+	gint work_monitor = gdk_screen_get_monitor_at_window (screen, gtk_widget_get_window (GTK_WIDGET (presentation_window)));
+	return work_monitor;
+}
+
+static void
+ev_dscwindow_setup_from_metadata (EvDSCWindow *ev_dscwindow)
+{
+	if (!ev_dscwindow->priv->metadata)
+		return;
+	gint	int_value;
+	gdouble double_value;
+	if (ev_metadata_get_double (ev_dscwindow->priv->metadata, "presentation-time", &double_value))
+		gtk_spin_button_set_value (GTK_SPIN_BUTTON (ev_dscwindow->priv->spinner),double_value);
+	if (ev_metadata_get_int (ev_dscwindow->priv->metadata, "presentation-monitor", &int_value)) {
+		ev_dscwindow->priv->presentation_monitor = int_value;
+	} else {
+		ev_dscwindow->priv->presentation_monitor = (ev_dscwindow->priv->moveback_monitor +  1) % 2;
+	}
+}
+
+static gboolean
+ev_dscwindow_windows_placement (EvDSCWindow *ev_dscwindow)
+{
+	if (!EV_IS_DSCWINDOW (ev_dscwindow))
+		return FALSE;
+
+	gint num_monitors = get_num_monitors (GTK_WINDOW (ev_dscwindow));
+	if (num_monitors == 2) {
+		GdkRectangle coords;
+		GdkScreen *screen = gtk_window_get_screen (GTK_WINDOW (ev_dscwindow));
+		gint presentation_monitor = ev_dscwindow->priv->presentation_monitor;
+		gint control_monitor = (presentation_monitor + 1) % 2;
+
+		gdk_screen_get_monitor_geometry (screen, control_monitor, &coords);
+		gtk_window_unmaximize (GTK_WINDOW (ev_dscwindow));
+		gtk_window_move (GTK_WINDOW (ev_dscwindow), coords.x, coords.y);
+		gtk_window_maximize (GTK_WINDOW (ev_dscwindow));
+
+		gdk_screen_get_monitor_geometry (screen, presentation_monitor,&coords);
+		gtk_window_move (GTK_WINDOW (ev_dscwindow->priv->presentation_window), coords.x, coords.y);
+
+		return TRUE;
+	} else
+		return FALSE;
+}
+
+static void
+ev_dscwindow_switch_monitors (EvDSCWindow *ev_dscwindow)
+{
+	gint num_monitors = get_num_monitors (GTK_WINDOW (ev_dscwindow));
+	if (num_monitors == 2) {
+		ev_dscwindow->priv->presentation_monitor = (ev_dscwindow->priv->presentation_monitor + 1) % 2;
+		if (ev_dscwindow->priv->metadata)
+			ev_metadata_set_int (ev_dscwindow->priv->metadata,
+			        "presentation-monitor", ev_dscwindow->priv->presentation_monitor);
+	}
+	ev_dscwindow_windows_placement (ev_dscwindow);
+}
+
+static void
+ev_dscwindow_sidebar_visibility_cb (GtkWidget *sidebar)
+{
+	gtk_widget_set_visible (sidebar, !(gtk_widget_get_visible(sidebar)));
+}
+
+static void
+ev_dscwindow_set_page (EvDSCWindow *ev_dscwindow, gint page)
+{
+	if((ev_dscwindow->priv->page == 0) && (page == 1))
+		ev_presentation_timer_start (EV_PRESENTATION_TIMER (ev_dscwindow->priv->timer));
+	if(!(ev_dscwindow->priv->page == page)) {
+		ev_dscwindow->priv->page = page;
+		if(ev_document_model_get_page (ev_dscwindow->priv->model) != page)
+			ev_document_model_set_page(ev_dscwindow->priv->model, page);
+		if(ev_document_model_get_page (ev_dscwindow->priv->notes_model) != page)
+			ev_document_model_set_page(ev_dscwindow->priv->notes_model, page);
+		if(ev_view_presentation_get_current_page (EV_VIEW_PRESENTATION(ev_dscwindow->priv->presentation_view)) != page);
+			ev_view_presentation_set_page (EV_VIEW_PRESENTATION(ev_dscwindow->priv->presentation_view), page);
+		ev_presentation_timer_set_page (EV_PRESENTATION_TIMER(ev_dscwindow->priv->timer), page);
+	}
+}
+
+static void
+ev_dscwindow_presentation_time_cb (EvDSCWindow *ev_dscwindow)
+{
+	gint time = gtk_spin_button_get_value_as_int (GTK_SPIN_BUTTON (ev_dscwindow->priv->spinner));
+	ev_presentation_timer_set_time (EV_PRESENTATION_TIMER (ev_dscwindow->priv->timer),time);
+	if (ev_dscwindow->priv->metadata)
+		ev_metadata_set_double (ev_dscwindow->priv->metadata, "presentation-time", time);
+}
+
+static void
+ev_dscwindow_page_changed_cb (EvDocumentModel *model,
+			      GParamSpec      *pspec,
+			      EvDSCWindow     *ev_dscwindow)
+{
+	ev_dscwindow_set_page (ev_dscwindow, ev_document_model_get_page (model));
+}
+
+static void
+ev_dscwindow_presentation_page_changed_cb (EvViewPresentation   *pview,
+					   GParamSpec 		*pspec,
+					   EvDSCWindow		*ev_dscwindow)
+{
+	ev_dscwindow_set_page (ev_dscwindow, ev_view_presentation_get_current_page (pview));
+}
+
+static gboolean
+ev_dscwindow_notes_interaction (GtkContainer *container, EvDSCWindow *ev_dscwindow)
+{
+	GtkWidget *dialog;
+
+	dialog = gtk_file_chooser_dialog_new (
+		_("Open Document"),
+		GTK_WINDOW (ev_dscwindow),
+		GTK_FILE_CHOOSER_ACTION_OPEN,
+		GTK_STOCK_CANCEL, GTK_RESPONSE_REJECT,
+		GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT,
+		NULL);
+
+	ev_document_factory_add_filters (dialog, NULL);
+	gtk_file_chooser_set_select_multiple (GTK_FILE_CHOOSER (dialog), FALSE);
+	gtk_file_chooser_set_local_only (GTK_FILE_CHOOSER (dialog), TRUE);
+	char *uri;
+	if (ev_dscwindow->priv->metadata &&
+	    ev_metadata_get_string (ev_dscwindow->priv->metadata, "notes-uri", &uri))
+		gtk_file_chooser_set_uri (GTK_FILE_CHOOSER (dialog),uri);
+
+	if (gtk_dialog_run (GTK_DIALOG (dialog)) == GTK_RESPONSE_ACCEPT)
+	{
+		uri = gtk_file_chooser_get_uri (GTK_FILE_CHOOSER (dialog));
+		GError * error = NULL;
+		ev_view_set_loading (EV_VIEW (ev_dscwindow->priv->notesview), TRUE);
+
+		if (ev_dscwindow->priv->notes_document) {
+			ev_document_load (ev_dscwindow->priv->notes_document, uri, &error);
+		} else {
+			ev_dscwindow->priv->notes_document = ev_document_factory_get_document (uri,
+				&error);
+		}
+		if (error == NULL){
+			if (ev_dscwindow->priv->metadata)
+				ev_metadata_set_string (ev_dscwindow->priv->metadata,
+					"notes-uri", uri);
+			ev_dscwindow->priv->notes_model = ev_document_model_new ();
+			ev_document_model_set_document (ev_dscwindow->priv->notes_model,
+							ev_dscwindow->priv->notes_document);
+			ev_document_model_set_continuous (ev_dscwindow->priv->notes_model,
+							  FALSE);
+			ev_document_model_set_dual_page (ev_dscwindow->priv->notes_model,
+							 FALSE);
+			ev_document_model_set_sizing_mode (ev_dscwindow->priv->notes_model,
+							   EV_SIZING_BEST_FIT);
+			ev_document_model_set_page (ev_dscwindow->priv->notes_model,
+			        ev_document_model_get_page (ev_dscwindow->priv->model));
+			ev_view_set_model(EV_VIEW(ev_dscwindow->priv->notesview),
+					  ev_dscwindow->priv->notes_model);
+			g_signal_connect (G_OBJECT(ev_dscwindow->priv->notes_model),
+					  "notify::page",
+					  G_CALLBACK (ev_dscwindow_page_changed_cb),
+					  ev_dscwindow);
+		}
+	}
+	g_free (uri);
+	gtk_widget_destroy (dialog);
+
+	return TRUE;
+}
+
+EvDSCWindow *
+ev_dscwindow_get_control (void)
+{
+	static EvDSCWindow *control = NULL;
+
+	if (!control || !EV_IS_DSCWINDOW (control)) {
+		control = EV_DSCWINDOW (g_object_new (EV_TYPE_DSCWINDOW, NULL));
+	}
+
+	return control;
+}
+
+void
+ev_dscwindow_set_presentation   (EvDSCWindow    *ev_dscwindow,
+				 EvWindow       *presentation_window,
+				 EvDocument     *document,
+				 EvViewPresentation *pview,
+				 EvMetadata     *metadata)
+{
+	if (!EV_IS_WINDOW (presentation_window) || !EV_IS_DSCWINDOW (ev_dscwindow) ||
+	    !EV_IS_VIEW_PRESENTATION (pview) || !EV_IS_DOCUMENT (document) )
+		return;
+	ev_dscwindow->priv->presentation_window = GTK_WIDGET(presentation_window);
+	ev_dscwindow->priv->presentation_document = document;
+	ev_dscwindow->priv->presentation_view = EV_VIEW_PRESENTATION(pview);
+	ev_dscwindow->priv->page = ev_view_presentation_get_current_page (pview);
+	ev_dscwindow->priv->moveback_monitor = ev_dscwindow_get_presentation_window_monitor (ev_dscwindow);
+	ev_dscwindow->priv->metadata = metadata;
+
+	ev_document_model_set_document(ev_dscwindow->priv->model, document);
+	ev_document_model_set_page(ev_dscwindow->priv->model, ev_dscwindow->priv->page);
+	/*signals*/
+	g_signal_connect_swapped (ev_dscwindow->priv->presentation_view,
+				  "destroy",
+				  G_CALLBACK (gtk_widget_destroy),
+				  GTK_WIDGET (ev_dscwindow));
+	g_signal_connect (G_OBJECT(ev_dscwindow->priv->model),
+			  "notify::page",
+			  G_CALLBACK (ev_dscwindow_page_changed_cb),
+			  ev_dscwindow);
+	g_signal_connect (G_OBJECT(ev_dscwindow->priv->presentation_view),
+			  "notify::page",
+			  G_CALLBACK (ev_dscwindow_presentation_page_changed_cb),
+			  ev_dscwindow);
+	ev_presentation_timer_set_pages (EV_PRESENTATION_TIMER(ev_dscwindow->priv->timer),
+		ev_document_get_n_pages (document));
+	/* Wait for windows to get shown before moving them */
+	while(gtk_events_pending())
+		gtk_main_iteration();
+	/* something like http://mail.gnome.org/archives/gtk-list/2008-June/msg00061.html */
+	ev_dscwindow_setup_from_metadata (ev_dscwindow);
+	ev_dscwindow_windows_placement (ev_dscwindow);
+}
+
+static gboolean
+ev_dscwindow_end (GtkWidget *widget, GdkEvent *event)
+{
+	EvDSCWindow *ev_dscwindow = EV_DSCWINDOW(widget);
+	EvWindow *ev_window = EV_WINDOW(ev_dscwindow->priv->presentation_window);
+	ev_window_stop_presentation (ev_window, TRUE);
+	gtk_widget_destroy (widget);
+	return TRUE;
+}
+
+static void
+ev_dscwindow_init (EvDSCWindow *ev_dscwindow)
+{
+
+	ev_dscwindow->priv = EV_DSCWINDOW_GET_PRIVATE (ev_dscwindow);
+	ev_dscwindow->priv->page = 0;
+	ev_dscwindow->priv->moveback_monitor = -1;
+	ev_dscwindow->priv->notes_document = NULL;
+
+	gtk_window_set_title (GTK_WINDOW (ev_dscwindow), _("Presentation Control"));
+
+	GtkWidget *hpaned = gtk_paned_new (GTK_ORIENTATION_HORIZONTAL);
+	GtkWidget *vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
+
+	ev_dscwindow->priv->model = ev_document_model_new ();
+	ev_document_model_set_continuous (ev_dscwindow->priv->model, FALSE);
+	ev_document_model_set_dual_page (ev_dscwindow->priv->model, FALSE);
+	ev_document_model_set_sizing_mode (ev_dscwindow->priv->model,
+		EV_SIZING_BEST_FIT);
+
+	ev_dscwindow->priv->sidebar = ev_sidebar_new ();
+	ev_sidebar_set_model (EV_SIDEBAR (ev_dscwindow->priv->sidebar),
+			      ev_dscwindow->priv->model);
+
+	GtkWidget *sidebar_widget;
+	sidebar_widget = ev_sidebar_thumbnails_new ();
+	ev_sidebar_add_page (EV_SIDEBAR (ev_dscwindow->priv->sidebar),
+			     sidebar_widget);
+
+	ev_dscwindow->priv->notesview_scrolled_window =
+		GTK_WIDGET (g_object_new(GTK_TYPE_SCROLLED_WINDOW,
+			    "shadow-type",
+			    GTK_SHADOW_IN,
+			    NULL));
+	ev_dscwindow->priv->notesview = ev_view_new ();
+	gtk_container_add (GTK_CONTAINER (ev_dscwindow->priv->notesview_scrolled_window),
+			   ev_dscwindow->priv->notesview);
+	ev_dscwindow->priv->notes_model = ev_dscwindow->priv->model;
+	ev_view_set_model (EV_VIEW (ev_dscwindow->priv->notesview),
+			   ev_dscwindow->priv->notes_model);
+	gtk_paned_pack1 (GTK_PANED (hpaned),
+			 ev_dscwindow->priv->sidebar,
+			 FALSE,
+			 TRUE);
+	gtk_paned_pack2 (GTK_PANED (hpaned),
+			 ev_dscwindow->priv->notesview_scrolled_window,
+			 FALSE,
+			 FALSE);
+
+	gtk_box_pack_start(GTK_BOX(vbox),hpaned,TRUE,TRUE,0);
+
+	GtkWidget *expander = gtk_expander_new (_("Dualscreen configuration"));
+	gtk_expander_set_expanded (GTK_EXPANDER (expander), FALSE);
+	GtkWidget *toolbar = gtk_toolbar_new ();
+
+	GtkToolItem *b_switch = gtk_tool_button_new (NULL, _("Switch monitors"));
+	gtk_tool_item_set_tooltip_text (b_switch,
+	        _("Switch monitors, In case of more than two monitor window placing has to be manual."));
+	gtk_tool_button_set_icon_name (GTK_TOOL_BUTTON (b_switch), "object-flip-horizontal");
+	gtk_toolbar_insert (GTK_TOOLBAR (toolbar), b_switch, -1);
+	g_signal_connect_swapped (b_switch, "clicked",
+		G_CALLBACK (ev_dscwindow_switch_monitors), ev_dscwindow);
+
+	GtkToolItem *b_notes = gtk_tool_button_new_from_stock (GTK_STOCK_OPEN);
+	gtk_tool_button_set_label (GTK_TOOL_BUTTON(b_notes), _("Load notes..."));
+	gtk_tool_item_set_tooltip_text (b_notes, _("Load your notes document"));
+	gtk_toolbar_insert (GTK_TOOLBAR (toolbar), b_notes, -1);
+	g_signal_connect (b_notes, "clicked",
+		G_CALLBACK (ev_dscwindow_notes_interaction), ev_dscwindow);
+
+	GtkToolItem *b_close = gtk_tool_button_new_from_stock (GTK_STOCK_CLOSE);
+	gtk_tool_button_set_label (GTK_TOOL_BUTTON(b_close), _("End presentation"));
+	gtk_tool_item_set_tooltip_text (b_close, _("End presentation"));
+	gtk_toolbar_insert (GTK_TOOLBAR (toolbar), b_close, -1);
+	g_signal_connect_swapped (b_close, "clicked",
+		G_CALLBACK (ev_dscwindow_end), ev_dscwindow);
+
+	GtkToolItem *b_sidebar = gtk_tool_button_new_from_stock (GTK_STOCK_PAGE_SETUP);
+	gtk_tool_button_set_label (GTK_TOOL_BUTTON(b_sidebar), _("Show sidebar"));
+	gtk_tool_item_set_tooltip_text (b_sidebar, _("Show/hide sidebar"));
+	gtk_toolbar_insert (GTK_TOOLBAR (toolbar), b_sidebar, -1);
+	g_signal_connect_swapped (b_sidebar, "clicked",
+		G_CALLBACK (ev_dscwindow_sidebar_visibility_cb), ev_dscwindow->priv->sidebar);
+
+	GtkToolItem *b_spinner = gtk_tool_item_new ();
+	GtkWidget* alignment = gtk_alignment_new (0.0f, 0.5f, 1.0f, 0.1f);
+	GtkAdjustment *timer_adjust = gtk_adjustment_new (-1.0, -1.0,
+		MAX_PRESENTATION_TIME, 1.0, 10.0, 10.0);
+	ev_dscwindow->priv->spinner = gtk_spin_button_new (timer_adjust, 1.0, 0);
+	g_signal_connect_swapped (ev_dscwindow->priv->spinner, "value-changed",
+	        G_CALLBACK (ev_dscwindow_presentation_time_cb), ev_dscwindow);
+	gtk_container_add (GTK_CONTAINER (b_spinner), alignment);
+	gtk_container_add (GTK_CONTAINER (alignment), ev_dscwindow->priv->spinner);
+	gtk_tool_item_set_tooltip_text (b_spinner,
+	        _("To enable timer, set presentation timer to expected time in minutes. Timer starts by changing from first slide to second one. Value -1 means disabled."));
+	gtk_toolbar_insert (GTK_TOOLBAR (toolbar), b_spinner, -1);
+
+	gtk_container_add (GTK_CONTAINER (expander), toolbar);
+
+	GtkWidget *hpan = gtk_paned_new (GTK_ORIENTATION_HORIZONTAL);
+	gtk_paned_pack1 (GTK_PANED(hpan), expander, FALSE, TRUE);
+	ev_dscwindow->priv->timer = ev_presentation_timer_new ();
+	gtk_paned_pack2 (GTK_PANED(hpan),ev_dscwindow->priv->timer, FALSE, FALSE);
+
+	gtk_box_pack_end (GTK_BOX (vbox), hpan, FALSE, TRUE, 0);
+	gtk_container_add (GTK_CONTAINER (ev_dscwindow), vbox);
+	gtk_widget_show_all(vbox);
+	gtk_paned_set_position (GTK_PANED (hpan), SIDEBAR_DEFAULT_SIZE);
+	gtk_paned_set_position (GTK_PANED (hpaned), SIDEBAR_DEFAULT_SIZE);
+}
+
+static void
+ev_dscwindow_dispose (GObject *obj)
+{
+	EvDSCWindow *ev_dscwindow = EV_DSCWINDOW (obj);
+	EvDSCWindowPrivate *priv = EV_DSCWINDOW (ev_dscwindow)->priv;
+	EvWindow *ev_window = EV_WINDOW(priv->presentation_window);
+	if(EV_IS_WINDOW (ev_window)) {
+		if (priv->moveback_monitor >= 0) {
+			GtkWindow *presentation_window = GTK_WINDOW (priv->presentation_window);
+			GdkRectangle coords;
+
+			gdk_screen_get_monitor_geometry (gtk_window_get_screen (presentation_window),
+						 priv->moveback_monitor, &coords);
+			gtk_window_move (presentation_window, coords.x, coords.y);
+		}
+	}
+	G_OBJECT_CLASS (ev_dscwindow_parent_class)->dispose (obj);
+}
+
+static void
+ev_dscwindow_class_init (EvDSCWindowClass *ev_dscwindow_class)
+{
+	GObjectClass *g_object_class = G_OBJECT_CLASS (ev_dscwindow_class);
+	g_type_class_add_private (g_object_class, sizeof (EvDSCWindowPrivate));
+	g_object_class->dispose  = ev_dscwindow_dispose;
+}
+
+GtkWidget *
+ev_dscwindow_new (void)
+{
+	EvDSCWindow *ev_dscwindow;
+
+	ev_dscwindow = g_object_new (EV_TYPE_DSCWINDOW, "type", GTK_WINDOW_TOPLEVEL, NULL);
+	return GTK_WIDGET (ev_dscwindow);
+}

--- a/shell/ev-dualscreen.h
+++ b/shell/ev-dualscreen.h
@@ -1,0 +1,65 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8; c-indent-level: 8 -*- */
+/* this file is part of evince, a gnome document viewer
+ *
+ *  Copyright (C) 2007 Johannes Buchner
+ *
+ *  Author:
+ *    Johannes Buchner <buchner.johannes@gmx.at>
+ *    Lukas Bezdicka <255993@mail.muni.cz>
+ *
+ * Evince is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Evince is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef EV_DUALSCREEN_H
+#define EV_DUALSCREEN_H
+
+#include "ev-window.h"
+#include "ev-view-presentation.h"
+#include "ev-metadata.h"
+
+G_BEGIN_DECLS
+
+typedef struct _EvDSCWindow EvDSCWindow;
+typedef struct _EvDSCWindowClass EvDSCWindowClass;
+typedef struct _EvDSCWindowPrivate EvDSCWindowPrivate;
+
+#define EV_TYPE_DSCWINDOW	        (ev_dscwindow_get_type())
+#define EV_DSCWINDOW(object)	        (G_TYPE_CHECK_INSTANCE_CAST((object), EV_TYPE_DSCWINDOW, EvDSCWindow))
+#define EV_DSCWINDOW_CLASS(klass)	(G_TYPE_CHECK_CLASS_CAST((klass), EV_TYPE_DSCWINDOW, EvDSCWindowClass))
+#define EV_IS_DSCWINDOW(object)		(G_TYPE_CHECK_INSTANCE_TYPE((object), EV_TYPE_DSCWINDOW))
+#define EV_IS_DSCWINDOW_CLASS(klass)	(G_TYPE_CHECK_CLASS_TYPE((klass), EV_TYPE_DSCWINDOW))
+#define EV_DSCWINDOW_GET_CLASS(object)  (G_TYPE_INSTANCE_GET_CLASS((object), EV_TYPE_DSCWINDOW, EvDSCWindowClass))
+
+struct _EvDSCWindowClass {
+	GtkWindowClass		base_class;
+};
+
+struct _EvDSCWindow {
+	GtkWindow		 base_instance;
+	EvDSCWindowPrivate      *priv;
+};
+
+GType		ev_dscwindow_get_type   (void);
+GtkWidget      *ev_dscwindow_new (void);
+void		ev_dscwindow_set_presentation   (EvDSCWindow		*ev_dscwindow,
+						 EvWindow		*presentation_window,
+						 EvDocument	        *document,
+						 EvViewPresentation     *pview,
+						 EvMetadata		*metadata);
+EvDSCWindow*    ev_dscwindow_get_control (void);
+
+G_END_DECLS
+
+#endif /* EV_DUALSCREEN_H */

--- a/shell/ev-presentation-timer.c
+++ b/shell/ev-presentation-timer.c
@@ -1,0 +1,190 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8; c-indent-level: 8 -*- */
+/* this file is part of evince, a gnome document viewer
+ *
+ *
+ *  Author:
+ *    Lukas Bezdicka <255993@mail.muni.cz>
+ *
+ * Evince is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Evince is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <cairo.h>
+#include <glib/gi18n.h>
+#include <gtk/gtk.h>
+#include <math.h>
+
+#include "ev-presentation-timer.h"
+
+struct _EvPresentationTimerPrivate
+{
+	gint	   time;
+	gint	   remaining;
+	guint	   page;
+	guint	   pages;
+	guint	   timeout;
+	gboolean   running;
+};
+
+#define EV_PRESENTATION_TIMER_GET_PRIVATE(object) \
+	(G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_PRESENTATION_TIMER, EvPresentationTimerPrivate))
+
+G_DEFINE_TYPE (EvPresentationTimer, ev_presentation_timer, GTK_TYPE_DRAWING_AREA);
+
+static gdouble
+ev_presentation_timer_progress (gdouble time, gdouble remaining)
+{
+	return remaining/(time*60);
+}
+
+static gboolean
+ev_presentation_timer_draw(GtkWidget *timer, cairo_t *cr)
+{
+	EvPresentationTimer *ev_timer = EV_PRESENTATION_TIMER(timer);
+	GtkAllocation allocation;
+	gtk_widget_get_allocation (timer, &allocation);
+	cairo_set_source_rgb (cr, 0, 0, 0);
+	cairo_set_line_width (cr, 5);
+	guint pos = (allocation.width/ev_timer->priv->pages)*ev_timer->priv->page;
+	cairo_move_to (cr,pos,2);
+	cairo_line_to (cr,pos,allocation.height);
+	cairo_stroke (cr);
+	if(ev_timer->priv->running && ev_timer->priv->time > 0 && ev_timer->priv->remaining > 0)
+	{
+		gdouble progress = ev_presentation_timer_progress (ev_timer->priv->time,
+								   ev_timer->priv->remaining)*(allocation.width);
+		cairo_rectangle (cr, allocation.width-progress,
+				 10,
+				 (allocation.width-(allocation.width-progress))-10,
+				 allocation.height-5);
+		cairo_stroke_preserve (cr);
+		cairo_fill(cr);
+	}
+	return FALSE;
+}
+
+static gboolean
+timeout_cb (gpointer data)
+{
+	EvPresentationTimer *ev_timer = EV_PRESENTATION_TIMER(data);
+	ev_timer->priv->remaining--;
+
+	if(time >= 0 && ev_timer->priv->remaining >= 0)
+	{
+		gtk_widget_queue_draw(GTK_WIDGET(ev_timer));
+	} else
+		ev_timer->priv->running = FALSE;
+	return ev_timer->priv->running;
+}
+
+void
+ev_presentation_timer_set_pages (EvPresentationTimer *ev_timer, guint pages)
+{
+	if(!EV_IS_PRESENTATION_TIMER (ev_timer))
+		return;
+	ev_timer->priv->pages = pages;
+}
+
+void
+ev_presentation_timer_set_page (EvPresentationTimer *ev_timer, guint page)
+{
+	if(!EV_IS_PRESENTATION_TIMER (ev_timer))
+		return;
+	if (page >= ev_timer->priv->pages)
+	{
+		page = ev_timer->priv->pages;
+		ev_timer->priv->running=FALSE;
+	}
+	ev_timer->priv->page = page;
+	gtk_widget_queue_draw(GTK_WIDGET(ev_timer));
+}
+
+static void
+ev_presentation_timer_init (EvPresentationTimer *ev_timer)
+{
+	ev_timer->priv = EV_PRESENTATION_TIMER_GET_PRIVATE (ev_timer);
+	ev_timer->priv->page = 0;
+	ev_timer->priv->pages = 0;
+	ev_timer->priv->remaining = 0;
+	ev_timer->priv->time = 0;
+	ev_timer->priv->timeout = 0;
+	ev_timer->priv->running = FALSE;
+}
+
+void
+ev_presentation_timer_start (EvPresentationTimer *ev_timer)
+{
+	if (!EV_IS_PRESENTATION_TIMER (ev_timer))
+		return;
+	if (ev_timer->priv->running == FALSE)
+	{
+		ev_timer->priv->remaining = (ev_timer->priv->time)*60;
+		ev_timer->priv->running = TRUE;
+		ev_timer->priv->timeout = g_timeout_add_seconds (1, timeout_cb, ev_timer);
+	}
+}
+
+void
+ev_presentation_timer_stop (EvPresentationTimer *ev_timer)
+{
+	if (!EV_IS_PRESENTATION_TIMER (ev_timer))
+		return;
+	if (ev_timer->priv->timeout > 0)
+		g_source_remove (ev_timer->priv->timeout);
+	ev_timer->priv->remaining = 0;
+}
+
+void
+ev_presentation_timer_set_time (EvPresentationTimer *ev_timer,
+				gint time)
+{
+	if (!EV_IS_PRESENTATION_TIMER (ev_timer))
+		return;
+	if(ev_timer->priv->running)
+		ev_timer->priv->remaining = ((ev_timer->priv->remaining)/(ev_timer->priv->time)*time);
+	ev_timer->priv->time = (time < -1)? -1:time;
+}
+
+static void
+ev_presentation_timer_dispose (GObject *gobject)
+{
+	EvPresentationTimer *ev_timer = EV_PRESENTATION_TIMER (gobject);
+	EvPresentationTimerPrivate *priv = EV_PRESENTATION_TIMER (ev_timer)->priv;
+	if (priv->timeout > 0)
+		g_source_remove (priv->timeout);
+	G_OBJECT_CLASS (ev_presentation_timer_parent_class)->dispose (gobject);
+}
+
+static void
+ev_presentation_timer_class_init (EvPresentationTimerClass *klass)
+{
+	GObjectClass    *object_class = G_OBJECT_CLASS (klass);
+	GtkWidgetClass  *widget_class = GTK_WIDGET_CLASS (klass);
+	g_type_class_add_private (object_class, sizeof (EvPresentationTimerPrivate));
+	widget_class->draw = ev_presentation_timer_draw;
+	object_class->dispose =  ev_presentation_timer_dispose;
+}
+
+GtkWidget *
+ev_presentation_timer_new (void)
+{
+	EvPresentationTimer     *ev_timer;
+
+	ev_timer = g_object_new (EV_TYPE_PRESENTATION_TIMER, NULL);
+        return GTK_WIDGET (ev_timer);
+}

--- a/shell/ev-presentation-timer.h
+++ b/shell/ev-presentation-timer.h
@@ -1,0 +1,63 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8; c-indent-level: 8 -*- */
+/* this file is part of evince, a gnome document viewer
+ *
+ *
+ *  Author:
+ *    Lukas Bezdicka <255993@mail.muni.cz>
+ *
+ * Evince is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Evince is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef _EV_PRESENTATION_TIMER_H_
+#define _EV_PRESENTATION_TIMER_H_
+
+G_BEGIN_DECLS
+
+typedef struct _EvPresentationTimerClass	EvPresentationTimerClass;
+typedef struct _EvPresentationTimer		EvPresentationTimer;
+typedef struct _EvPresentationTimerPrivate      EvPresentationTimerPrivate;
+
+#define EV_TYPE_PRESENTATION_TIMER     		(ev_presentation_timer_get_type ())
+#define EV_PRESENTATION_TIMER(object)  		(G_TYPE_CHECK_INSTANCE_CAST ((object), EV_TYPE_PRESENTATION_TIMER, EvPresentationTimer))
+#define EV_PRESENTATION_TIMER_CLASS(klass)      (G_TYPE_CHECK_CLASS_CAST ((klass), EV_TYPE_PRESENTATION_TIMER, EvPresentationTimerClass))
+#define EV_IS_PRESENTATION_TIMER(object)	(G_TYPE_CHECK_INSTANCE_TYPE ((object), EV_TYPE_PRESENTATION_TIMER))
+#define EV_IS_PRESENTATION_TIMER_CLASS(klass)   (G_TYPE_CHECK_CLASS_TYPE ((klass), EV_TYPE_PRESENTATION_TIMER))
+#define EV_PRESENTATION_TIMER_GET_CLASS(object) (G_TYPE_INSTANCE_GET_CLASS ((object), EV_TYPE_PRESENTATION_TIMER, EvPresentationTimerClass))
+
+struct _EvPresentationTimerClass
+{
+	GtkDrawingAreaClass parent_class;
+};
+
+struct _EvPresentationTimer
+{
+	GtkDrawingArea			parent_instance;
+	EvPresentationTimerPrivate     *priv;
+};
+
+void			ev_presentation_timer_set_pages		(EvPresentationTimer *ev_timer,
+								 guint pages);
+void			ev_presentation_timer_set_page		(EvPresentationTimer *ev_timer,
+								 guint page);
+void			ev_presentation_timer_start		(EvPresentationTimer *ev_timer);
+void			ev_presentation_timer_stop		(EvPresentationTimer *ev_timer);
+void			ev_presentation_timer_set_time		(EvPresentationTimer *ev_timer,
+								 gint time);
+GType			ev_presentation_timer_get_type		(void);
+GtkWidget	       *ev_presentation_timer_new		(void);
+
+G_END_DECLS
+
+#endif /* _EV_PRESENTATION_TIMER_H_ */

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -53,6 +53,7 @@
 #include "ev-document-annotations.h"
 #include "ev-document-type-builtins.h"
 #include "ev-document-misc.h"
+#include "ev-dualscreen.h"
 #include "ev-file-exporter.h"
 #include "ev-file-helpers.h"
 #include "ev-file-monitor.h"
@@ -330,9 +331,6 @@ static void     ev_window_stop_fullscreen               (EvWindow         *windo
 							 gboolean          unfullscreen_window);
 static void     ev_window_cmd_view_fullscreen           (GtkAction        *action,
 							 EvWindow         *window);
-static void     ev_window_run_presentation              (EvWindow         *window);
-static void     ev_window_stop_presentation             (EvWindow         *window,
-							 gboolean          unfullscreen_window);
 static void     ev_window_cmd_view_presentation         (GtkAction        *action,
 							 EvWindow         *window);
 static void     ev_view_popup_cmd_open_link             (GtkAction        *action,
@@ -4379,7 +4377,7 @@ ev_window_view_presentation_focus_out (EvWindow *window)
 	return FALSE;
 }
 
-static void
+void
 ev_window_run_presentation (EvWindow *window)
 {
 	gboolean fullscreen_window = TRUE;
@@ -4433,9 +4431,18 @@ ev_window_run_presentation (EvWindow *window)
 
 	if (window->priv->metadata && !ev_window_is_empty (window))
 		ev_metadata_set_boolean (window->priv->metadata, "presentation", TRUE);
+
+        if ( get_num_monitors(GTK_WINDOW(window)) > 1) {
+                EvDSCWindow *control = ev_dscwindow_get_control();
+                gtk_window_present (GTK_WINDOW (control));
+                ev_dscwindow_set_presentation   (control, window,
+                                         window->priv->document,
+                                         EV_VIEW_PRESENTATION(window->priv->presentation_view),
+                                         window->priv->metadata);
+        }
 }
 
-static void
+void
 ev_window_stop_presentation (EvWindow *window,
 			     gboolean  unfullscreen_window)
 {

--- a/shell/ev-window.h
+++ b/shell/ev-window.h
@@ -82,6 +82,10 @@ void		ev_window_open_document                  (EvWindow       *ev_window,
                                                           EvWindowRunMode mode,
                                                           const gchar    *search_string);
 gboolean	ev_window_is_empty	                 (const EvWindow *ev_window);
+void            ev_window_run_presentation               (EvWindow       *ev_window);
+void            ev_window_stop_presentation              (EvWindow       *ev_window,
+                                                          gboolean        unfullscreen_window);
+
 void		ev_window_print_range                    (EvWindow       *ev_window,
                                                           int             first_page,
                                                           int		 last_page);


### PR DESCRIPTION
In case of having more than two monitors evince will start fullscreen window with presentation and another one with slides and notes.

https://bugzilla.gnome.org/show_bug.cgi?id=454731
