### PR TITLE
Fix malformed preprocessor conditional on s390x

### DIFF
--- a/cut-n-paste/unarr/lzmasdk/CpuArch.h
+++ b/cut-n-paste/unarr/lzmasdk/CpuArch.h
@@ -174,7 +174,7 @@ MY_CPU_LE_UNALIGN means that CPU is LITTLE ENDIAN and CPU supports unaligned mem
 #ifndef MY_CPU_NAME
   #ifdef MY_CPU_LE
     #define MY_CPU_NAME "LE"
-  #elif MY_CPU_BE
+  #elif defined (MY_CPU_BE)
     #define MY_CPU_NAME "BE"
   #else
     /*


### PR DESCRIPTION
MY_CPU_NAME expands to an empty string, so defined (MY_CPU_NAME) is needed.