### PR TITLE
Add "c" and "d" shortcuts to help overlay

### DIFF
--- a/shell/help-overlay.ui
+++ b/shell/help-overlay.ui
@@ -230,6 +230,20 @@
                 <property name="accelerator">a</property>
               </object>
             </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Allow continuous scroll</property>
+                <property name="accelerator">c</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Dual page view</property>
+                <property name="accelerator">d</property>
+              </object>
+            </child>
           </object>
         </child>
         <child>

--- a/shell/help-overlay.ui
+++ b/shell/help-overlay.ui
@@ -233,7 +233,7 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
-                <property name="title" translatable="yes" context="shortcut window">Allow continuous scroll</property>
+                <property name="title" translatable="yes" context="shortcut window">Allow continuous scrolling</property>
                 <property name="accelerator">c</property>
               </object>
             </child>


### PR DESCRIPTION
There are two undocumented shortcuts for toggling continuous scroll lock (c) and dual page view (d). This PR just adds them to the help overlay.