### PR TITLE
Update Persian translation

### DIFF
--- a/po/fa.po
+++ b/po/fa.po
@@ -1703,7 +1703,7 @@ msgstr "بازخوانی سند"
 #: ../shell/help-overlay.ui.h:8
 msgctxt "shortcut window"
 msgid "Selecting and copying text"
-msgstr "انتخاب و رونوشت از متن"
+msgstr "انتخاب کردن و رونوشت از متن"
 
 #: ../shell/help-overlay.ui.h:9
 msgctxt "shortcut window"


### PR DESCRIPTION
Selecting was translated wrong so a fixed and changed it to "انتخاب کردن".