### PR TITLE
made dual-page-odd-left default

### DIFF
--- a/data/org.gnome.Evince.gschema.xml
+++ b/data/org.gnome.Evince.gschema.xml
@@ -74,7 +74,7 @@
       <summary>Show two pages side by side.</summary>
     </key>
     <key name="dual-page-odd-left" type="b">
-      <default>false</default>
+      <default>true</default>
       <summary>Show the first page (odd page) on the left (when displaying two pages side by side)</summary>
     </key>
     <key name="fullscreen" type="b">


### PR DESCRIPTION
Files start from page 1.
so in case of dual-page-odd-left=false, first page is display to right side and left side remains blank which is strange. So I changed dual-page-odd-left to true so first page is displayed on left side.