### PR TITLE
thumbnailer: start watchdog before document loading

### DIFF
--- a/thumbnailer/evince-thumbnailer.c
+++ b/thumbnailer/evince-thumbnailer.c
@@ -275,16 +275,18 @@ main (int argc, char *argv[])
                 return -1;
 
 	file = g_file_new_for_commandline_arg (input);
+
+	if (time_limit)
+	    time_monitor_start (input); 
+
 	document = evince_thumbnailer_get_document (file);
 	g_object_unref (file);
 
 	if (!document) {
-		ev_shutdown ();
-		return -2;
+	    time_monitor_stop ();
+	    ev_shutdown ();
+	    return -2;
 	}
-
-        if (time_limit)
-                time_monitor_start (input);
 
 	if (!evince_thumbnail_pngenc_get (document, output, size)) {
 		g_object_unref (document);


### PR DESCRIPTION
The watchdog timer was previously started only after `evince_thumbnailer_get_document()` returned, leaving document loading, backend initialization and remote file copying outside the intended timeout protection window.

Start the watchdog before loading the document and ensure all subsequent exit paths stop the monitor correctly after activation.

This allows hangs during document loading to be terminated by the intended 15-second timeout.

Fixes #2150